### PR TITLE
/var/atlassian/application-data should be owned by root

### DIFF
--- a/recipes/standalone.rb
+++ b/recipes/standalone.rb
@@ -1,6 +1,6 @@
 directory File.dirname(node['jira']['home_path']) do
-  owner node['jira']['user']
-  group node['jira']['group']
+  owner 'root'
+  group 'root'
   mode 00755
   action :create
   recursive true


### PR DESCRIPTION
I respectfully disagree with #105 and furthermore it introduces #108, where the cookbook now fails to converge because the `jira` user doesn't exist before it is referenced in the directory resource.

`/var/atlassian/application-data` should be owned by root (and this also agrees with the [confluence cookbook](https://github.com/parallels-cookbooks/confluence/blob/master/recipes/linux_standalone.rb#L20-L35))
`/var/atlassian/application-data/jira` is managed by the user resource and so is created after the user & group exists

Fix #108 