### PR TITLE
Update default.rb

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -48,7 +48,7 @@ else
   default['jira']['proxy']['ssl']['port'] = 443
 end
 
-default['apache']['listen'] |= ["*:#{node['jira']['apache2']['port']}", "*:#{node['jira']['apache2']['ssl']['port']}"]
+default['apache']['listen'] = ["*:#{node['jira']['apache2']['port']}", "*:#{node['jira']['apache2']['ssl']['port']}"]
 
 case node['platform_family']
 when 'rhel'


### PR DESCRIPTION
  Recipe Compile Error in /tmp/kitchen/cache/cookbooks/jira/attributes/default.rb
       ================================================================================

       NoMethodError
       -------------
       undefined method `|' for {}:Chef::Node::VividMash

       Cookbook Trace:
       ---------------
         /tmp/kitchen/cache/cookbooks/jira/attributes/default.rb:51:in `from_file'

       Relevant File Content:
       ----------------------
       /tmp/kitchen/cache/cookbooks/jira/attributes/default.rb:

        44:    default['jira']['proxy']['name']        = node['jira']['apache2']['virtual_host_name']
        45:    default['jira']['proxy']['ssl']['port'] = node['jira']['apache2']['ssl']['port']
        46:  else
        47:    default['jira']['proxy']['name']        = node['fqdn']
        48:    default['jira']['proxy']['ssl']['port'] = 443
        49:  end
        50:
        51>> default['apache']['listen'] |= ["*:#{node['jira']['apache2']['port']}", "*:#{node['jira']['apache2']['ssl']['port']}"]
        52:
        53:  case node['platform_family']
        54:  when 'rhel'
        55:    default['jira']['apache2']['ssl']['certificate_file'] = '/etc/pki/tls/certs/localhost.crt'
        56:    default['jira']['apache2']['ssl']['key_file']         = '/etc/pki/tls/private/localhost.key'
        57:  else
        58:    default['jira']['apache2']['ssl']['certificate_file'] = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
        59:    default['jira']['apache2']['ssl']['key_file']         = '/etc/ssl/private/ssl-cert-snakeoil.key'
        60:  end